### PR TITLE
Fix the GMT build script path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ addons:
 
 before_install:
     # Install GMT master branch
-    - curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt-master.sh | bash
+    - curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
     # Check GMT installation
     - gmt --version
     - gmt-config --all


### PR DESCRIPTION
The GMT build script was renamed to `build-gmt.sh` in https://github.com/GenericMappingTools/gmt/pull/3841.